### PR TITLE
update metrics labels and make default default store name

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,16 +460,16 @@ Example of metrics:
 ```
 # HELP konfig_loader_reload Number of config loader reload
 # TYPE konfig_loader_reload counter
-konfig_loader_reload{loader_name="config-files",result="failure",store_name=""} 0.0
-konfig_loader_reload{loader_name="config-files",result="success",store_name=""} 1.0
+konfig_loader_reload{loader="config-files",result="failure",store="root"} 0.0
+konfig_loader_reload{loader="config-files",result="success",store="root"} 1.0
 
 # HELP konfig_loader_reload_duration Histogram for the config reload duration
 # TYPE konfig_loader_reload_duration summary
-konfig_loader_reload_duration{loader_name="config-files",store_name="",quantile="0.5"} 0.001227641
-konfig_loader_reload_duration{loader_name="config-files",store_name="",quantile="0.9"} 0.001227641
-konfig_loader_reload_duration{loader_name="config-files",store_name="",quantile="0.99"} 0.001227641
-konfig_loader_reload_duration_sum{loader_name="config-files",store_name=""} 0.001227641
-konfig_loader_reload_duration_count{loader_name="config-files",store_name=""} 1.0
+konfig_loader_reload_duration{loader="config-files",store="root",quantile="0.5"} 0.001227641
+konfig_loader_reload_duration{loader="config-files",store="root",quantile="0.9"} 0.001227641
+konfig_loader_reload_duration{loader="config-files",store="root",quantile="0.99"} 0.001227641
+konfig_loader_reload_duration_sum{loader="config-files",store=""} 0.001227641
+konfig_loader_reload_duration_count{loader="config-files",store=""} 1.0
 ```
 
 To enable metrics, you must pass a custom config when creating a config store: 

--- a/metrics.go
+++ b/metrics.go
@@ -31,18 +31,18 @@ func (lw *loaderWatcher) setMetrics() {
 		configReloadSuccess: configReloadCounterVec.
 			WithLabelValues(
 				metricsSuccessLabel,
-				lw.s.cfg.Name,
+				lw.s.name,
 				lw.Name(),
 			),
 		configReloadFailure: configReloadCounterVec.
 			WithLabelValues(
 				metricsFailureLabel,
-				lw.s.cfg.Name,
+				lw.s.name,
 				lw.Name(),
 			),
 		configReloadDuration: configReloadDurationSummaryVec.
 			WithLabelValues(
-				lw.s.cfg.Name,
+				lw.s.name,
 				lw.Name(),
 			),
 	}
@@ -55,7 +55,7 @@ func (c *store) initMetrics() {
 				Name: MetricsConfigReload,
 				Help: "Number of config loader reload",
 			},
-			[]string{"result", "store_name", "loader_name"},
+			[]string{"result", "store", "loader"},
 		),
 		MetricsConfigReloadDuration: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
@@ -63,7 +63,7 @@ func (c *store) initMetrics() {
 				Help:       "Histogram for the config reload duration",
 				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 			},
-			[]string{"store_name", "loader_name"},
+			[]string{"store", "loader"},
 		),
 	}
 }


### PR DESCRIPTION
- Changing metrics labels from `store_name` -> `store` and `loader_name` -> `loader`
- Making default store name `root` be used in metrics label