### PR TITLE
UPT: nui release commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/vault v1.0.1
 	github.com/jinzhu/copier v0.0.0-20180308034124-7e38e58719c3
-	github.com/lalamove/nui v0.0.1
+	github.com/lalamove/nui v0.0.2-0.20190122032433-946f150453be
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pierrec/lz4 v0.0.0-20181005164709-635575b42742


### PR DESCRIPTION
# Objective
As `nui` previous `v 0.0.1` have an invalid module name. After pull request https://github.com/lalamove/nui/pull/1. We need to update the `go.mod` in `konfig` as well. Otherwise, `go mod` will still get the `v 0.0.1` release from github.

# After update
![image](https://user-images.githubusercontent.com/5622516/51511471-61d91b00-1e3c-11e9-8fed-fca6659419a1.png)

Thx francois to offer this awesome tools for go engineer. 

cc @francoispqt 