### PR TITLE
klfile: remove defer drom the loop

### DIFF
--- a/loader/klfile/fileloader.go
+++ b/loader/klfile/fileloader.go
@@ -163,12 +163,13 @@ func (f *Loader) Load(cfg konfig.Values) error {
 		if err != nil {
 			return err
 		}
-		defer fd.Close()
 
 		// we parse the file
 		if err := file.Parser.Parse(fd, cfg); err != nil {
+			fd.Close()
 			return err
 		}
+		fd.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
Hi! There is better not use `defer` inside the loop, because `defer` guaranteed to executed at the end of the function. `defer` works as a stack, so, in your loop,  `fd.Close()` will be pushing to the stack and at the end of the loop it'll be executing at reverse order. Check a little [snippet](https://play.golang.org/p/LZZ_1duu08n)
In this PR i've just moved `fd.Close` at the end of the loop and to the error handling. But probably you want to handle it on the different way(each file on the loop read at the goroutine, or so)