### PR TITLE
Feature/hooks values

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,374 +2,661 @@
 
 
 [[projects]]
+  digest = "1:e4b30804a381d7603b8a344009987c1ba351c26043501b23b8c7ce21f0b67474"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
+  pruneopts = ""
   revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
   version = "v0.3.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:0a776e52fa4deb432e3c382436ed79c2e20fb6fd02061782c11e3e3a58b86d78"
   name = "github.com/armon/go-metrics"
   packages = ["."]
+  pruneopts = ""
   revision = "f0300d1749da6fa982027e449ec0c7a145510c3c"
 
 [[projects]]
   branch = "master"
+  digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = ""
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:512883404c2a99156e410e9880e3bb35ecccc0c07c1159eb204b5f3ef3c431b3"
   name = "github.com/bitly/go-simplejson"
   packages = ["."]
+  pruneopts = ""
   revision = "aabad6e819789e569bd6aabf444c935aa9ba1e44"
   version = "v0.5.0"
 
 [[projects]]
+  digest = "1:0bc9fe59e23786a6d5f5b65d2676904d29aafcc79fa9fca4472fe0d15ee15656"
   name = "github.com/coreos/etcd"
-  packages = ["auth/authpb","etcdserver/api/v3rpc/rpctypes","etcdserver/etcdserverpb","mvcc/mvccpb","pkg/types"]
+  packages = [
+    "auth/authpb",
+    "etcdserver/api/v3rpc/rpctypes",
+    "etcdserver/etcdserverpb",
+    "mvcc/mvccpb",
+    "pkg/types",
+  ]
+  pruneopts = ""
   revision = "d57e8b8d97adfc4a6c224fe116714bf1a1f3beb9"
   version = "v3.3.12"
 
 [[projects]]
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:00ebcb711885e2c33dec037f6ce3f3f20c60b82fb773497c15df1edfb74dffad"
   name = "github.com/francoispqt/gojay"
   packages = ["."]
-  revision = "f2cc13a668caf474b5d5806c7f1adbbe4ce28524"
-  version = "1.2.7"
+  pruneopts = ""
+  revision = "90d953358b68936b4791b8db205b3a5918b1b7a5"
+  version = "1.2.8"
 
 [[projects]]
+  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = ""
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = ""
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:fd53b471edb4c28c7d297f617f4da0d33402755f58d6301e7ca1197ef0a90937"
   name = "github.com/gogo/protobuf"
-  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor"]
-  revision = "4cbf7e384e768b4e01799441fdf2a706a5635ae7"
-  version = "v1.2.0"
+  packages = [
+    "gogoproto",
+    "proto",
+    "protoc-gen-gogo/descriptor",
+  ]
+  pruneopts = ""
+  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
+  version = "v1.2.1"
 
 [[projects]]
+  digest = "1:530233672f656641b365f8efb38ed9fba80e420baff2ce87633813ab3755ed6d"
   name = "github.com/golang/mock"
   packages = ["gomock"]
+  pruneopts = ""
   revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:d3d38150b6d77b2aad42a9e105170538b6563518993d43df78a1add6e31cce62"
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = ""
+  revision = "c823c79ea1570fb5ff454033735a8e68575d1d0f"
+  version = "v1.3.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:6a6322a15aa8e99bd156fbba0aae4e5d67b4bb05251d860b348a45dfdcba9cce"
   name = "github.com/golang/snappy"
   packages = ["."]
-  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+  pruneopts = ""
+  revision = "2a8bb927dd31d8daada140a5d09578521ce5c36a"
+  version = "v0.0.1"
 
 [[projects]]
+  digest = "1:ad92aa49f34cbc3546063c7eb2cabb55ee2278b72842eda80e2a20a8a06a8d73"
   name = "github.com/google/uuid"
   packages = ["."]
-  revision = "9b3b1e0f5f99ae461456d768e7d301a7acdaa2d8"
-  version = "v1.1.0"
+  pruneopts = ""
+  revision = "0cd6bf5da1e1c83f8b45653022c74f71af0538a4"
+  version = "v1.1.1"
 
 [[projects]]
+  digest = "1:918e6d5252c1726e32b0597f5c3875cafbbae62cf6f78a79594931fd906143e1"
   name = "github.com/hashicorp/consul"
-  packages = ["api","lib/freeport","testutil","testutil/retry"]
-  revision = "c97c712e96e0e53308054d5e1180289fe02dce38"
-  version = "v1.4.2"
+  packages = [
+    "api",
+    "lib/freeport",
+    "testutil",
+    "testutil/retry",
+  ]
+  pruneopts = ""
+  revision = "567e41ff6b096a478333c804d5c18264050bc3f8"
+  version = "v1.4.3"
 
 [[projects]]
+  digest = "1:8e3bd93036b4a925fe2250d3e4f38f21cadb8ef623561cd80c3c50c114b13201"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
+  pruneopts = ""
   revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:05334858a0cfb538622a066e065287f63f42bee26a7fda93a789674225057201"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
+  pruneopts = ""
   revision = "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18"
   version = "v0.5.0"
 
 [[projects]]
+  digest = "1:c5466dfad4c14bf8e52a34b0eb98f1301acc1e304e0f0ff2c51c356ca1b86747"
   name = "github.com/hashicorp/go-immutable-radix"
   packages = ["."]
+  pruneopts = ""
   revision = "27df80928bb34bb1b0d6d0e01b9e679902e7a6b5"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:72308fdd6d5ef61106a95be7ca72349a5565809042b6426a3cfb61d99483b824"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
+  pruneopts = ""
   revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:776139dc18d63ef223ffaca5d8e9a3057174890f84393d3c881e934100b66dbc"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
+  pruneopts = ""
   revision = "73489d0a1476f0c9e6fb03f9c39241523a496dfd"
   version = "v0.5.2"
 
 [[projects]]
+  digest = "1:c25fc9af3d03f56e1d8827e6d823dcc3318be2902d8182601cf7538834bb346f"
   name = "github.com/hashicorp/go-rootcerts"
   packages = ["."]
+  pruneopts = ""
   revision = "63503fb4e1eca22f9ae0f90b49c5d5538a0e87eb"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:24ee99da0190535baad44a5df2710ca2e116d615fcaaffcf3b79b476450af917"
   name = "github.com/hashicorp/go-sockaddr"
   packages = ["."]
-  revision = "3aed17b5ee41761cc2b04f2a94c7107d428967e5"
-  version = "v1.0.1"
+  pruneopts = ""
+  revision = "c7188e74f6acae5a989bdc959aa779f8b9f42faf"
+  version = "v1.0.2"
 
 [[projects]]
+  digest = "1:0038a7f43b51c8b2a8cd03b5372e73f8eadfe156484c2ae8185ae836f8ebc2cd"
   name = "github.com/hashicorp/go-uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "4f571afc59f3043a65f8fe6bf46d887b10a01d43"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:85f8f8d390a03287a563e215ea6bd0610c858042731a8b42062435a0dcbc485f"
   name = "github.com/hashicorp/golang-lru"
   packages = ["simplelru"]
-  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
-  version = "v0.5.0"
+  pruneopts = ""
+  revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
+  version = "v0.5.1"
 
 [[projects]]
+  digest = "1:d14365c51dd1d34d5c79833ec91413bfbb166be978724f15701e17080dc06dec"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token",
+  ]
+  pruneopts = ""
   revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:2dd628a226f3a5ff16360f868114731d2734924eef4a49cb64d0781c6c9c5e7e"
   name = "github.com/hashicorp/serf"
   packages = ["coordinate"]
+  pruneopts = ""
   revision = "b89a09ebd4b1b570e0076d5097272e67c10ac4f6"
   version = "v0.8.2"
 
 [[projects]]
+  digest = "1:f45b7e07f44ceda7d619a2b1307e19468321f6d06897d63e3fdafd20261c0f77"
   name = "github.com/hashicorp/vault"
-  packages = ["api","helper/compressutil","helper/consts","helper/hclutil","helper/jsonutil","helper/parseutil","helper/strutil"]
+  packages = [
+    "api",
+    "helper/compressutil",
+    "helper/consts",
+    "helper/hclutil",
+    "helper/jsonutil",
+    "helper/parseutil",
+    "helper/strutil",
+  ]
+  pruneopts = ""
   revision = "85909e3373aa743c34a6a0ab59131f61fd9e8e43"
   version = "v1.0.3"
 
 [[projects]]
+  digest = "1:31bfd110d31505e9ffbc9478e31773bf05bf02adcaeb9b139af42684f9294c13"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = ""
   revision = "7c29201646fa3de8506f701213473dd407f19646"
   version = "v0.3.7"
 
 [[projects]]
   branch = "master"
+  digest = "1:d0b151e4f07350afcca336335d5d3698e91ed95e9ffb54fe894806e8899590ef"
   name = "github.com/jinzhu/copier"
   packages = ["."]
+  pruneopts = ""
   revision = "7e38e58719c33e0d44d585c4ab477a30f8cb82dd"
 
 [[projects]]
+  digest = "1:f57ebba94f901202a52132284a01a272d833b158cb5b579bae6b75915bcddc8d"
   name = "github.com/lalamove/nui"
-  packages = ["ncontext","nfs","ngetter","nlogger","nstrings"]
+  packages = [
+    "ncontext",
+    "nfs",
+    "ngetter",
+    "nlogger",
+    "nstrings",
+  ]
+  pruneopts = ""
   revision = "d2745b1cf314264f7fc8068dc9a82c8078f8fa4d"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:961dc3b1d11f969370533390fdf203813162980c858e1dabe827b60940c909a5"
   name = "github.com/magiconair/properties"
   packages = ["."]
+  pruneopts = ""
   revision = "c2353362d570a7bfa228149c62842019201cfb71"
   version = "v1.8.0"
 
 [[projects]]
+  digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = ""
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:fe5503ff1a1bf5fd2b9b6b744274bd7b1c20acb012182ca3da0ff4528cb885f6"
   name = "github.com/micro/go-config"
-  packages = [".","encoder","encoder/hcl","encoder/json","encoder/toml","encoder/xml","encoder/yaml","loader","loader/memory","reader","reader/json","source","source/file","source/memory"]
+  packages = [
+    ".",
+    "encoder",
+    "encoder/hcl",
+    "encoder/json",
+    "encoder/toml",
+    "encoder/xml",
+    "encoder/yaml",
+    "loader",
+    "loader/memory",
+    "reader",
+    "reader/json",
+    "source",
+    "source/file",
+    "source/memory",
+  ]
+  pruneopts = ""
   revision = "2a4da1fca4d75c5e1fb254a60b4aa987c73fab08"
-  version = "v0.14.0"
+  version = "v1.0.0"
 
 [[projects]]
+  digest = "1:6dbb0eb72090871f2e58d1e37973fe3cb8c0f45f49459398d3fc740cb30e13bd"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
+  pruneopts = ""
   revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:9adf43f9a17af07a6d587e3b493e2111ad8e07283d5cd58e44e70d23bf6dc644"
   name = "github.com/mitchellh/go-testing-interface"
   packages = ["."]
+  pruneopts = ""
   revision = "6d0b8010fcc857872e42fc6c931227569016843c"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:bcc46a0fbd9e933087bef394871256b5c60269575bb661935874729c65bbbf60"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = ""
   revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
   version = "v1.1.2"
 
 [[projects]]
+  digest = "1:a5484d4fa43127138ae6e7b2299a6a52ae006c7f803d98d717f60abf3e97192e"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
   version = "v1.2"
 
 [[projects]]
+  digest = "1:894aef961c056b6d85d12bac890bf60c44e99b46292888bfa66caf529f804457"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
+  pruneopts = ""
   revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:21b276e792044150a96175edd51d653649b9fd175c51a4613f2741b411c6d674"
   name = "github.com/pierrec/lz4"
-  packages = [".","internal/xxh32"]
-  revision = "473cd7ce01a1113208073166464b98819526150e"
-  version = "v2.0.8"
+  packages = [
+    ".",
+    "internal/xxh32",
+  ]
+  pruneopts = ""
+  revision = "062282ea0dcff40c9fb8525789eef9644b1fbd6e"
+  version = "v2.1.0"
 
 [[projects]]
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
   version = "v0.8.1"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/internal"]
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+  ]
+  pruneopts = ""
   revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
   version = "v0.9.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:cd67319ee7536399990c4b00fae07c3413035a53193c644549a676091507cadc"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = ""
   revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
 
 [[projects]]
+  digest = "1:96af18a3819d2ff7d6aa07e6e50955b11e477dbc8b890324c67462b84adca56b"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = ""
   revision = "cfeb6f9992ffa54aaa4f2170ade4067ee478b250"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:a29813277de981ce33148b3f1906bba492af2ce97237c050f62a6b48cfdae721"
   name = "github.com/prometheus/procfs"
-  packages = [".","internal/util","nfs","xfs"]
-  revision = "f8d8b3f739bd91a7c0462cb55235ef63c79c9abc"
+  packages = [
+    ".",
+    "internal/util",
+    "iostats",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = ""
+  revision = "d0f344d83b0c80a1bc03b547a2374a9ec6711144"
 
 [[projects]]
+  digest = "1:2389dc36373649d729e089057acf50aca054098f4e252596754d9ea76277fc07"
   name = "github.com/radovskyb/watcher"
   packages = ["."]
+  pruneopts = ""
   revision = "d8b41ca2397a9b5cfc26adb10edbbcde40187a87"
   version = "v1.0.6"
 
 [[projects]]
+  digest = "1:4244255905cb95c3c98894d671367f84a6292608ae528936fe46ba9c86f68393"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
+  pruneopts = ""
   revision = "51a8f68e6c24dc43f1e371749c89a267de4ebc53"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:d9f371ceb44045ca4405b65fed916e4b45396340b9e8674851c3d652f6351cde"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem",
+  ]
+  pruneopts = ""
   revision = "f4711e4db9e9a1d3887343acb72b2bbfc2f686f5"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:ae3493c780092be9d576a1f746ab967293ec165e8473425631f06658b6212afc"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = ""
   revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:cc15ae4fbdb02ce31f3392361a70ac041f4f02e0485de8ffac92bd8033e3d26e"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  revision = "4a4406e478ca629068e7768fc33f3f044173c0a6"
-  version = "v1.0.0"
+  pruneopts = ""
+  revision = "94f6ae3ed3bceceafa716478c5fbf8d29ca601a1"
+  version = "v1.1.0"
 
 [[projects]]
+  digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
 
 [[projects]]
+  digest = "1:90fe60ab6f827e308b0c8cc1e11dce8ff1e96a927c8b171271a3cb04dd517606"
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "6d33b5a963d922d182c91e8a1c88d81fd150cfd4"
-  version = "v1.3.1"
+  pruneopts = ""
+  revision = "9e56dacc08fbbf8c9ee2dbc717553c758ce42bc9"
+  version = "v1.3.2"
 
 [[projects]]
+  digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
   name = "github.com/stretchr/testify"
-  packages = ["assert","require"]
+  packages = [
+    "assert",
+    "require",
+  ]
+  pruneopts = ""
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:0bc9fe59e23786a6d5f5b65d2676904d29aafcc79fa9fca4472fe0d15ee15656"
   name = "go.etcd.io/etcd"
   packages = ["clientv3"]
+  pruneopts = ""
   revision = "d57e8b8d97adfc4a6c224fe116714bf1a1f3beb9"
   version = "v3.3.12"
 
 [[projects]]
   branch = "master"
+  digest = "1:e9152dabd6b276edd0f1d51598e5745dcda9411315d216863bb46b13e523300c"
   name = "golang.org/x/net"
-  packages = ["context","http/httpguts","http2","http2/hpack","idna","internal/timeseries","trace"]
-  revision = "3a22650c66bd7f4fb6d1e8072ffd7b75c8a27898"
+  packages = [
+    "context",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "trace",
+  ]
+  pruneopts = ""
+  revision = "5c2c250b6a70e39b74bb544433a348a892b10530"
 
 [[projects]]
   branch = "master"
+  digest = "1:9c1e747af61ab955fba74a79e87d5843a5d1d504e3ef86480f76e6a4e3a49136"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "983097b1a8a340cd1cc7df17d735154d89e10b1a"
+  pruneopts = ""
+  revision = "fead79001313d15903fb4605b4a1b781532cd93e"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:9522af4be529c108010f95b05f1022cb872f2b9ff8b101080f554245673466e1"
   name = "golang.org/x/time"
   packages = ["rate"]
-  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
+  pruneopts = ""
+  revision = "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef"
 
 [[projects]]
   branch = "master"
+  digest = "1:6a8803e2481c92e20f9fc654b8ddfbd5a2a802c0454d0bc5b7a018b218282205"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "4b09977fb92221987e99d190c8f88f2c92727a29"
+  pruneopts = ""
+  revision = "5fe7a883aa19554f42890211544aa549836af7b7"
 
 [[projects]]
+  digest = "1:b6c17b0c657f047118ae59b358950b28515914512cf3de02388cc42e33a92520"
   name = "google.golang.org/grpc"
-  packages = [".","balancer","balancer/base","balancer/roundrobin","binarylog/grpc_binarylog_v1","codes","connectivity","credentials","credentials/internal","encoding","encoding/proto","grpclog","health/grpc_health_v1","internal","internal/backoff","internal/binarylog","internal/channelz","internal/envconfig","internal/grpcrand","internal/grpcsync","internal/syscall","internal/transport","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap"]
-  revision = "a02b0774206b209466313a0b525d2c738fe407eb"
-  version = "v1.18.0"
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
+    "codes",
+    "connectivity",
+    "credentials",
+    "credentials/internal",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "health/grpc_health_v1",
+    "internal",
+    "internal/backoff",
+    "internal/binarylog",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/syscall",
+    "internal/transport",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+  ]
+  pruneopts = ""
+  revision = "2fdaae294f38ed9a121193c51ec99fecd3b13eb7"
+  version = "v1.19.0"
 
 [[projects]]
+  digest = "1:cedccf16b71e86db87a24f8d4c70b0a855872eb967cb906a66b95de56aefbd0d"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
   version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3749468a0e9f3cb65997a8e98459acc4591e2ee08d7c71576e4e7e1d280b86ff"
+  input-imports = [
+    "github.com/BurntSushi/toml",
+    "github.com/coreos/etcd/mvcc/mvccpb",
+    "github.com/davecgh/go-spew/spew",
+    "github.com/francoispqt/gojay",
+    "github.com/golang/mock/gomock",
+    "github.com/hashicorp/consul/api",
+    "github.com/hashicorp/consul/testutil",
+    "github.com/hashicorp/go-multierror",
+    "github.com/hashicorp/vault/api",
+    "github.com/jinzhu/copier",
+    "github.com/lalamove/nui/ncontext",
+    "github.com/lalamove/nui/nfs",
+    "github.com/lalamove/nui/ngetter",
+    "github.com/lalamove/nui/nlogger",
+    "github.com/lalamove/nui/nstrings",
+    "github.com/micro/go-config",
+    "github.com/micro/go-config/source/memory",
+    "github.com/pkg/errors",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/radovskyb/watcher",
+    "github.com/spf13/cast",
+    "github.com/spf13/viper",
+    "github.com/stretchr/testify/require",
+    "go.etcd.io/etcd/clientv3",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -275,6 +275,18 @@ configLoader.AddHooks(
 )
 ```
 
+### Adding hooks on keys
+Alternatively, you can add hooks on keys. Hooks on keys will match for prefix in order to run a hook when any key with a given prefix is updated. 
+A hook can only be ran once per load event, event if multiple keys match that hook.   
+```go
+konfig.RegisterKeyHook(
+    "db.",
+    func(s konfig.Store) error {
+        return nil
+    },
+)
+```
+
 # Closers
 *Closers* can be added to konfig so that if konfig fails to load, it will execute `Close()` on the registered *Closers*.
 ```go

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ configLoader.AddHooks(
 
 ### Adding hooks on keys
 Alternatively, you can add hooks on keys. Hooks on keys will match for prefix in order to run a hook when any key with a given prefix is updated. 
-A hook can only be ran once per load event, event if multiple keys match that hook.   
+A hook can only be run once per load event, even if multiple keys match that hook.   
 ```go
 konfig.RegisterKeyHook(
     "db.",

--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package konfig
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -307,12 +306,8 @@ func (c *store) Strict(keys ...string) Store {
 	return c
 }
 func (c *store) checkStrictKeys() error {
-	for _, k := range c.strictKeys {
-		if !c.Exists(k) {
-			return fmt.Errorf(ErrStrictKeyNotFoundMsg, k)
-		}
-	}
-	return nil
+	var m = c.m.Load().(s)
+	return m.checkStrictKeys(c.strictKeys)
 }
 
 // RunHooks runs all hooks and child groups hooks

--- a/config.go
+++ b/config.go
@@ -273,7 +273,7 @@ func (kh keyHooks) add(k string, f func(Store) error) {
 func (kh keyHooks) runForKeys(keys []string, c *store) error {
 	for k, h := range kh {
 		for _, kk := range keys {
-			if kk == k || strings.HasPrefix(kk, k) {
+			if strings.HasPrefix(kk, k) {
 				if err := h.Run(c); err != nil {
 					return err
 				}

--- a/config.go
+++ b/config.go
@@ -46,7 +46,7 @@ func (e ErrMissingConfig) Error() string {
 func DefaultConfig() *Config {
 	return &Config{
 		ExitCode: 1,
-		Logger:   nlogger.NewProvider(nlogger.New(os.Stdout, "CONFIG | ")),
+		Logger:   nlogger.NewProvider(nlogger.New(os.Stdout, "KONFIG | ")),
 		Name:     defaultName,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -277,6 +277,8 @@ func (kh keyHooks) runForKeys(keys []string, c *store) error {
 				if err := h.Run(c); err != nil {
 					return err
 				}
+				// make sure this hook runs only once even if there's a wide range of keys matching
+				break
 			}
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -265,6 +265,7 @@ type keyHooks map[string]LoaderHooks
 func (kh keyHooks) add(k string, f func(Store) error) {
 	if v, ok := kh[k]; ok {
 		v = append(v, f)
+		kh[k] = v
 		return
 	}
 	kh[k] = LoaderHooks{f}

--- a/config_test.go
+++ b/config_test.go
@@ -379,7 +379,7 @@ func TestConfigWatcherLoader(t *testing.T) {
 			reset()
 			Init(&Config{
 				ExitCode: 1,
-				Logger:   nlogger.NewProvider(nlogger.New(os.Stdout, "CONFIG | ")),
+				Logger:   nlogger.NewProvider(nlogger.New(os.Stdout, "KONFIG | ")),
 				Metrics:  true,
 			})
 			var c = instance()

--- a/config_test.go
+++ b/config_test.go
@@ -135,6 +135,7 @@ func TestConfigWatcherLoader(t *testing.T) {
 				// set our expectations
 				var l = NewMockLoader(ctrl)
 
+				l.EXPECT().Name().Times(3).Return("l")
 				l.EXPECT().MaxRetry().MinTimes(1).Return(2)
 				l.EXPECT().RetryDelay().MinTimes(1).Return(1 * time.Millisecond)
 
@@ -156,6 +157,7 @@ func TestConfigWatcherLoader(t *testing.T) {
 				// set our expectations
 				var l = NewMockLoader(ctrl)
 
+				l.EXPECT().Name().Times(3).Return("l")
 				l.EXPECT().MaxRetry().MinTimes(1).Return(2)
 				l.EXPECT().RetryDelay().MinTimes(1).Return(1 * time.Millisecond)
 
@@ -178,6 +180,7 @@ func TestConfigWatcherLoader(t *testing.T) {
 				// set our expectations
 				var l = NewMockLoader(ctrl)
 
+				l.EXPECT().Name().Times(3).Return("l")
 				l.EXPECT().MaxRetry().MinTimes(1).Return(2)
 				l.EXPECT().RetryDelay().MinTimes(1).Return(1 * time.Millisecond)
 
@@ -204,6 +207,7 @@ func TestConfigWatcherLoader(t *testing.T) {
 				var c = make(chan struct{}, 1)
 				var d = make(chan struct{})
 
+				l.EXPECT().Name().Times(3).Return("l")
 				l.EXPECT().MaxRetry().MinTimes(1).Return(2)
 				l.EXPECT().RetryDelay().MinTimes(1).Return(1 * time.Millisecond)
 
@@ -249,9 +253,11 @@ func TestConfigWatcherLoader(t *testing.T) {
 				var c2 = make(chan struct{}, 1)
 				var d2 = make(chan struct{})
 
+				l.EXPECT().Name().Times(3).Return("l")
 				l.EXPECT().MaxRetry().MinTimes(1).Return(2)
 				l.EXPECT().RetryDelay().MinTimes(1).Return(1 * time.Millisecond)
 
+				l2.EXPECT().Name().Times(3).Return("l2")
 				l2.EXPECT().Load(Values{}).MinTimes(1).Return(nil)
 
 				gomock.InOrder(
@@ -314,6 +320,9 @@ func TestConfigWatcherLoader(t *testing.T) {
 				var c2 = make(chan struct{}, 1)
 				var d2 = make(chan struct{})
 
+				l.EXPECT().Name().Times(3).Return("l")
+
+				l2.EXPECT().Name().Times(3).Return("l2")
 				l2.EXPECT().Load(Values{}).MinTimes(1).Return(nil)
 
 				gomock.InOrder(
@@ -368,7 +377,11 @@ func TestConfigWatcherLoader(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			// init the test
 			reset()
-			Init(DefaultConfig())
+			Init(&Config{
+				ExitCode: 1,
+				Logger:   nlogger.NewProvider(nlogger.New(os.Stdout, "CONFIG | ")),
+				Metrics:  true,
+			})
 			var c = instance()
 			c.cfg.NoExitOnError = true
 

--- a/loader.go
+++ b/loader.go
@@ -137,7 +137,7 @@ func (c *store) loaderLoadRetry(wl *loaderWatcher, retry int) error {
 	}
 
 	// we add the values to the store
-	v.load(wl.values, c)
+	var updatedKeys = v.load(wl.values, c)
 	wl.values = v
 
 	// if we have strict keys setup on the store and we have already loaded configs
@@ -149,7 +149,12 @@ func (c *store) loaderLoadRetry(wl *loaderWatcher, retry int) error {
 		}
 	}
 
-	// we run the hooks
+	// run key hooks
+	if len(updatedKeys) != 0 && c.keyHooks != nil {
+		return c.keyHooks.runForKeys(updatedKeys, c)
+	}
+
+	// run the loader hooks
 	if wl.loaderHooks != nil {
 		c.mut.Lock()
 		if err := wl.loaderHooks.Run(c); err != nil {

--- a/loader.go
+++ b/loader.go
@@ -136,18 +136,13 @@ func (c *store) loaderLoadRetry(wl *loaderWatcher, retry int) error {
 		return c.loaderLoadRetry(wl, retry+1)
 	}
 
-	// we add the values to the store
-	var updatedKeys = v.load(wl.values, c)
-	wl.values = v
-
-	// if we have strict keys setup on the store and we have already loaded configs
-	// we check those keys now, if they are not present, we will return the error.
-	if c.strictKeys != nil && c.loaded {
-		if err := c.checkStrictKeys(); err != nil {
-			c.cfg.Logger.Get().Error("Error while checking strict keys: " + err.Error())
-			return err
-		}
+	// we add the values to the store.
+	var updatedKeys, err = v.load(wl.values, c)
+	if err != nil {
+		return err
 	}
+
+	wl.values = v
 
 	// run key hooks
 	if len(updatedKeys) != 0 && c.keyHooks != nil {

--- a/loader_test.go
+++ b/loader_test.go
@@ -265,6 +265,13 @@ func TestLoaderLoadRetryKeyHooks(t *testing.T) {
 			return nil
 		},
 	)
+	c.RegisterKeyHook(
+		"test",
+		func(c Store) error {
+			ranTest++
+			return nil
+		},
+	)
 
 	var ranFoo int
 	c.RegisterKeyHook(
@@ -349,7 +356,7 @@ func TestLoaderLoadRetryKeyHooks(t *testing.T) {
 	err = c.loaderLoadRetry(wl, 0)
 	require.NotNil(t, err, "err should not be nil")
 
-	require.Equal(t, 2, ranTest, "ranTest should be 2")
+	require.Equal(t, 4, ranTest, "ranTest should be 2")
 	require.Equal(t, 3, ranFoo, "ranFoo should be 3")
 	require.Equal(t, 1, ranErr, "ranErr should be 1")
 }

--- a/loader_test.go
+++ b/loader_test.go
@@ -304,6 +304,7 @@ func TestLoaderLoadRetryKeyHooks(t *testing.T) {
 		mockL.EXPECT().Load(Values{}).Do(func(v Values) {
 			v["test"] = "test"
 			v["test.foo"] = "foo"
+			v["foo.test"] = "barr"
 			v["foo"] = "barr"
 		}).Return(nil),
 		mockL.EXPECT().Load(Values{}).Do(func(v Values) {

--- a/util.go
+++ b/util.go
@@ -15,7 +15,8 @@ func (m s) exists(k string) bool {
 	return ok
 }
 
-// exists returns a boolean indicating if the key exists in the map
+// checkStrictKeys checks if the given keys are present in the map. If a key is not
+// found checkStrictKeys returns a non nil error.
 func (m s) checkStrictKeys(keys []string) error {
 	for _, k := range keys {
 		if !m.exists(k) {

--- a/util.go
+++ b/util.go
@@ -9,6 +9,22 @@ import (
 
 type s map[string]interface{}
 
+// exists returns a boolean indicating if the key exists in the map
+func (m s) exists(k string) bool {
+	_, ok := m[k]
+	return ok
+}
+
+// exists returns a boolean indicating if the key exists in the map
+func (m s) checkStrictKeys(keys []string) error {
+	for _, k := range keys {
+		if !m.exists(k) {
+			return fmt.Errorf(ErrStrictKeyNotFoundMsg, k)
+		}
+	}
+	return nil
+}
+
 // Exists checks if a config key k is set in the Store
 func Exists(k string) bool {
 	return instance().Exists(k)

--- a/value.go
+++ b/value.go
@@ -113,7 +113,7 @@ func (val *value) set(k string, v interface{}) {
 	val.v.Store(nVal.Elem().Interface())
 }
 
-func (val *value) setValues(ox Values, x Values) {
+func (val *value) setValues(x s) {
 	val.mut.Lock()
 	defer val.mut.Unlock()
 
@@ -141,22 +141,10 @@ func (val *value) setValues(ox Values, x Values) {
 	var t = reflect.TypeOf(configValue)
 	var nVal = reflect.New(t)
 
-	copier.Copy(nVal.Interface(), configValue)
-
-	// reset to zero value keys not present anymore
-	for kk, vv := range ox {
-		if _, ok := x[kk]; !ok {
-			val.setStruct(
-				kk,
-				reflect.Zero(reflect.TypeOf(vv)).Interface(),
-				nVal,
-			)
-		}
-	}
-
 	for kk, vv := range x {
 		val.setStruct(kk, vv, nVal)
 	}
+
 	val.v.Store(nVal.Elem().Interface())
 }
 

--- a/value_test.go
+++ b/value_test.go
@@ -118,6 +118,7 @@ func TestSetStruct(t *testing.T) {
 				"submaptptr.bar.tt": 1,
 				"submaptptr.foo.vv": "woop",
 				"submaptptr.foo.tt": 1,
+				"subt.notfound":     1,
 			}
 
 			v.load(Values{

--- a/value_test.go
+++ b/value_test.go
@@ -182,7 +182,9 @@ func TestSetStruct(t *testing.T) {
 			require.Equal(t, "test", configValue.V)
 			require.Equal(t, "test2", configValue.T.VV)
 			require.Equal(t, 0, configValue.T.TT)
-			require.Equal(t, 0, configValue.SubT.TT)
+			require.Nil(t, configValue.SubT)
+			require.Nil(t, configValue.SubMapT)
+			require.Nil(t, configValue.SubMapTPtr)
 		},
 	)
 

--- a/value_test.go
+++ b/value_test.go
@@ -54,9 +54,11 @@ func TestSetStruct(t *testing.T) {
 				I64 int64   `konfig:"int64"`
 			}
 			type TestConfig struct {
-				V    string        `konfig:"v"`
-				T    TestConfigSub `konfig:"sub"`
-				SubT *TestConfigSub
+				V          string        `konfig:"v"`
+				T          TestConfigSub `konfig:"sub"`
+				SubT       *TestConfigSub
+				SubMapTPtr map[string]*TestConfigSub `konfig:"submaptptr"`
+				SubMapT    map[string]TestConfigSub  `konfig:"submapt"`
 			}
 
 			var expectedConfig = TestConfig{
@@ -72,6 +74,26 @@ func TestSetStruct(t *testing.T) {
 					VV: "",
 					TT: 2,
 				},
+				SubMapTPtr: map[string]*TestConfigSub{
+					"foo": &TestConfigSub{
+						VV: "woop",
+						TT: 1,
+					},
+					"bar": &TestConfigSub{
+						VV: "hello",
+						TT: 1,
+					},
+				},
+				SubMapT: map[string]TestConfigSub{
+					"foo": TestConfigSub{
+						VV: "woop",
+						TT: 1,
+					},
+					"bar": TestConfigSub{
+						VV: "hello",
+						TT: 1,
+					},
+				},
 			}
 
 			Init(DefaultConfig())
@@ -79,14 +101,23 @@ func TestSetStruct(t *testing.T) {
 			var tc TestConfig
 			require.NotPanics(t, func() { Bind(tc) })
 
+			// new values
 			var v = Values{
-				"v":           "test",
-				"sub.vv":      "test2",
-				"sub.tt":      1,
-				"subt.tt":     2,
-				"sub.bool":    true,
-				"sub.float64": 1.9,
-				"sub.int64":   int64(1),
+				"v":                 "test",
+				"sub.vv":            "test2",
+				"sub.tt":            1,
+				"subt.tt":           2,
+				"sub.bool":          true,
+				"sub.float64":       1.9,
+				"sub.int64":         int64(1),
+				"submapt.bar.vv":    "hello",
+				"submapt.bar.tt":    1,
+				"submapt.foo.vv":    "woop",
+				"submapt.foo.tt":    1,
+				"submaptptr.bar.vv": "hello",
+				"submaptptr.bar.tt": 1,
+				"submaptptr.foo.vv": "woop",
+				"submaptptr.foo.tt": 1,
 			}
 
 			v.load(Values{
@@ -101,6 +132,42 @@ func TestSetStruct(t *testing.T) {
 			require.Equal(t, true, configValue.T.B)
 			require.Equal(t, 1.9, configValue.T.F)
 			require.Equal(t, int64(1), configValue.T.I64)
+			require.Equal(
+				t,
+				&TestConfigSub{
+					VV: "woop",
+					TT: 1,
+				},
+				configValue.SubMapTPtr["foo"],
+				"SubMapT['foo'] should be equal",
+			)
+			require.Equal(
+				t,
+				&TestConfigSub{
+					VV: "hello",
+					TT: 1,
+				},
+				configValue.SubMapTPtr["bar"],
+				"SubMapT['bar'] should be equal",
+			)
+			require.Equal(
+				t,
+				TestConfigSub{
+					VV: "woop",
+					TT: 1,
+				},
+				configValue.SubMapT["foo"],
+				"SubMapT['foo'] should be equal",
+			)
+			require.Equal(
+				t,
+				TestConfigSub{
+					VV: "hello",
+					TT: 1,
+				},
+				configValue.SubMapT["bar"],
+				"SubMapT['bar'] should be equal",
+			)
 
 			require.Equal(t, expectedConfig, Value())
 

--- a/values.go
+++ b/values.go
@@ -61,6 +61,7 @@ func (x Values) load(ox Values, c *store) ([]string, error) {
 		}
 	}
 
+	// we didn't get any error, store the new config state
 	c.m.Store(nm)
 	return updatedKeys, nil
 }

--- a/values.go
+++ b/values.go
@@ -63,5 +63,6 @@ func (x Values) load(ox Values, c *store) ([]string, error) {
 
 	// we didn't get any error, store the new config state
 	c.m.Store(nm)
+
 	return updatedKeys, nil
 }

--- a/values.go
+++ b/values.go
@@ -46,11 +46,6 @@ func (x Values) load(ox Values, c *store) ([]string, error) {
 		}
 	}
 
-	// if there is a value bound we set it there also
-	if c.v != nil {
-		c.v.setValues(ox, x)
-	}
-
 	// if we have strict keys setup on the store and we have already loaded configs
 	// we check those keys now, if they are not present, we will return the error.
 	if c.strictKeys != nil && c.loaded {
@@ -59,6 +54,11 @@ func (x Values) load(ox Values, c *store) ([]string, error) {
 			c.cfg.Logger.Get().Error(err.Error())
 			return nil, err
 		}
+	}
+
+	// if there is a value bound we set it there also
+	if c.v != nil {
+		c.v.setValues(ox, x)
 	}
 
 	// we didn't get any error, store the new config state

--- a/values.go
+++ b/values.go
@@ -1,5 +1,7 @@
 package konfig
 
+import "reflect"
+
 // Values is the values attached to a loader
 type Values map[string]interface{}
 
@@ -8,23 +10,36 @@ func (x Values) Set(k string, v interface{}) {
 	x[k] = v
 }
 
-func (x Values) load(ox Values, c *store) {
+func (x Values) load(ox Values, c *store) []string {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
+	// load the previous key store
 	var m = c.m.Load().(s)
 
 	// we copy the previous store
 	// but we omit what was on the previous values
+	var updatedKeys = make([]string, 0, len(x))
 	var nm = make(s)
 	for kk, vv := range m {
+		// if key is not in old loader values
+		// add it to the new store
+		// else if key is in new loader values but value is different or key is
+		// in previous values but not in new ones
+		// we add it to updatedKeys list
 		if _, ok := ox[kk]; !ok {
 			nm[kk] = vv
+		} else if v, ok := x[kk]; (ok && !reflect.DeepEqual(v, vv)) || !ok { // value is different or not present anymore
+			updatedKeys = append(updatedKeys, kk)
 		}
 	}
 	// we add the new values
 	for kk, vv := range x {
 		nm[kk] = vv
+		// if key is not present in old store, add it to updatedKeys as we are adding a new key in
+		if _, ok := m[kk]; !ok {
+			updatedKeys = append(updatedKeys, kk)
+		}
 	}
 
 	// if there is a value bound we set it there also
@@ -33,4 +48,6 @@ func (x Values) load(ox Values, c *store) {
 	}
 
 	c.m.Store(nm)
+
+	return updatedKeys
 }

--- a/values.go
+++ b/values.go
@@ -58,7 +58,7 @@ func (x Values) load(ox Values, c *store) ([]string, error) {
 
 	// if there is a value bound we set it there also
 	if c.v != nil {
-		c.v.setValues(ox, x)
+		c.v.setValues(nm)
 	}
 
 	// we didn't get any error, store the new config state

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -13,14 +13,20 @@ func TestWatcher(t *testing.T) {
 		func(t *testing.T) {
 			var w = NopWatcher{}
 			require.Nil(t, w.Start())
+
 			var ctrl = gomock.NewController(t)
 			defer ctrl.Finish()
+
 			var mockL = NewMockLoader(ctrl)
+
 			var c = New(&Config{})
+
 			c.RegisterLoaderWatcher(
 				NewLoaderWatcher(mockL, w),
 			)
+
 			c.Watch()
+			require.Nil(t, w.Err())
 			time.Sleep(100 * time.Millisecond)
 		},
 	)


### PR DESCRIPTION
This MR adds hooks on values and handling of `map[string]struct` on bound value.

- Hooks on values: 
You can define hooks on a matching keys. It checks for prefix so you can match a range of keys to run a single hook. I was considering regexp but I think it's expensive and I don't think there's a meaningful use case. 
The syntax to register a key hook is:
```go
konfig.RegisterKeyHook(k, func(konfig.Store) error {
    return nil
})
```

- Handling `map[string]struct` on bound value: 
When unmarshaling the config state to the bound structure, we were only handling struct types. Now it can also handle `map[string]struct` to be able to unmarshal key value lists where the key is unknown.
