### PR TITLE
Supporting Versioned Vault KV Version 2

### DIFF
--- a/loader/klvault/README.md
+++ b/loader/klvault/README.md
@@ -1,5 +1,5 @@
 # Vault Loader
-Loads config values from a vault secrets
+Loads config values from a vault secrets engine
 
 # Usage
 
@@ -19,3 +19,15 @@ vaultLoader := klvault.New(&klvault.Config{
 	Renew: true,
 })
 ```
+
+It is possible to pass additional params to the vault secrets engine in the following manner:
+
+`Key: "/aws/creds/example-role?ttl=20m"`
+
+KV Secrets Engine - Version 2 (Versioned KV Store) is also supported by the loader, key from the versioned KV store can be accessed as follows:
+
+`Key: "/secret/data/my-versioned-key"`
+
+This will return the latest version of the key, a particular version of the secret can be accessed as follows:
+
+`Key: "/secret/data/my-versioned-key?version=1"`

--- a/loader/klvault/vaultloader.go
+++ b/loader/klvault/vaultloader.go
@@ -180,8 +180,15 @@ func (vl *Loader) Load(cs konfig.Values) error {
 		if err != nil {
 			return err
 		}
-		sData, ok := s.Data["data"].(map[string]interface{})
-		if !ok {
+		// checking for KV V2 for vault secret store
+		// confirming version exists on metadata and it is an int
+		if m, ok := s.Data["metadata"].(map[string]interface{}); ok {
+			kvData, dataOK := s.Data["data"].(map[string]interface{})
+			_, versionOK := m["version"].(int)
+			if versionOK && dataOK {
+				sData = kvData
+			}
+		} else {
 			sData = s.Data
 		}
 		if vl.cfg.Debug {

--- a/loader/klvault/vaultloader_test.go
+++ b/loader/klvault/vaultloader_test.go
@@ -44,7 +44,7 @@ func TestVaultLoader(t *testing.T) {
 
 				var lC = mocks.NewMockLogicalClient(ctrl)
 				vl.logicalClient = lC
-				lC.EXPECT().ReadWithData("dummy/secret/path", nil).Return(
+				lC.EXPECT().ReadWithData("dummy/secret/path", map[string][]string{}).Return(
 					&vault.Secret{
 						Data: map[string]interface{}{
 							"FOO": "BAR",
@@ -54,7 +54,7 @@ func TestVaultLoader(t *testing.T) {
 					nil,
 				)
 
-				lC.EXPECT().ReadWithData("dummy/secret/path2", nil).Return(
+				lC.EXPECT().ReadWithData("dummy/secret/path2", map[string][]string{}).Return(
 					&vault.Secret{
 						Data: map[string]interface{}{
 							"BAR": "FOO",
@@ -132,7 +132,7 @@ func TestVaultLoader(t *testing.T) {
 
 				var lC = mocks.NewMockLogicalClient(ctrl)
 				vl.logicalClient = lC
-				lC.EXPECT().ReadWithData("dummy/secret/path", nil).Return(
+				lC.EXPECT().ReadWithData("dummy/secret/path", map[string][]string{}).Return(
 					nil,
 					errors.New(""),
 				)

--- a/loader/klvault/vaultloader_test.go
+++ b/loader/klvault/vaultloader_test.go
@@ -2,7 +2,6 @@ package klvault
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -45,7 +44,6 @@ func TestVaultLoader(t *testing.T) {
 
 				var lC = mocks.NewMockLogicalClient(ctrl)
 				vl.logicalClient = lC
-				fmt.Println("here")
 				lC.EXPECT().ReadWithData("dummy/secret/path", nil).Return(
 					&vault.Secret{
 						Data: map[string]interface{}{
@@ -134,7 +132,7 @@ func TestVaultLoader(t *testing.T) {
 
 				var lC = mocks.NewMockLogicalClient(ctrl)
 				vl.logicalClient = lC
-				lC.EXPECT().Read("/dummy/secret/path").Return(
+				lC.EXPECT().ReadWithData("dummy/secret/path", nil).Return(
 					nil,
 					errors.New(""),
 				)

--- a/loader/klvault/vaultloader_test.go
+++ b/loader/klvault/vaultloader_test.go
@@ -2,6 +2,7 @@ package klvault
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -44,7 +45,8 @@ func TestVaultLoader(t *testing.T) {
 
 				var lC = mocks.NewMockLogicalClient(ctrl)
 				vl.logicalClient = lC
-				lC.EXPECT().Read("/dummy/secret/path").Return(
+				fmt.Println("here")
+				lC.EXPECT().ReadWithData("dummy/secret/path", nil).Return(
 					&vault.Secret{
 						Data: map[string]interface{}{
 							"FOO": "BAR",
@@ -54,7 +56,7 @@ func TestVaultLoader(t *testing.T) {
 					nil,
 				)
 
-				lC.EXPECT().Read("/dummy/secret/path2").Return(
+				lC.EXPECT().ReadWithData("dummy/secret/path2", nil).Return(
 					&vault.Secret{
 						Data: map[string]interface{}{
 							"BAR": "FOO",

--- a/loader/klvault/vaultloader_test.go
+++ b/loader/klvault/vaultloader_test.go
@@ -71,6 +71,12 @@ func TestVaultLoader(t *testing.T) {
 							"data": map[string]interface{}{
 								"VERSIONEDFOO": "FOO2",
 							},
+							"metadata": map[string]interface{}{
+								"created_time":  "2018-03-22T02:24:06.945319214Z",
+								"deletion_time": "",
+								"destroyed":     false,
+								"version":       1,
+							},
 						},
 						LeaseDuration: int(1 * time.Hour / time.Second),
 					},
@@ -81,6 +87,12 @@ func TestVaultLoader(t *testing.T) {
 						Data: map[string]interface{}{
 							"data": map[string]interface{}{
 								"OLDFOO": "FOO1",
+							},
+							"metadata": map[string]interface{}{
+								"created_time":  "2018-03-22T02:24:06.945319214Z",
+								"deletion_time": "",
+								"destroyed":     false,
+								"version":       1,
 							},
 						},
 						LeaseDuration: int(1 * time.Hour / time.Second),


### PR DESCRIPTION
As per #47 

* I have added support for Vault KV Version 2 (for supporting secret paths like `/secret/data/mysecret`) according to the Vault API for KV Version 2, by default this will return latest version of the secret. 

* This POC also adds support for requesting different versions of a particular secret by defining the key like `/secret/data/mysecret?version=2`

* For adding support for KV Version 2 I had to use ReadWithData, this opens up passing additional parameters to Vault API for example `/aws/sts/my-role?ttl=45m`

I have tested this change with Vault and tested for backwards compatibility. I can also add more documentation of this change if this MR moves forward. 

