### PR TITLE
Fix/vault kv version2

### DIFF
--- a/loader/klvault/vaultloader.go
+++ b/loader/klvault/vaultloader.go
@@ -189,10 +189,6 @@ func (vl *Loader) Load(cs konfig.Values) error {
 			if versionJSONNumberOK && dataOK {
 				sData = kvData
 			}
-			_, versionIntOK := m["version"].(int)
-			if versionIntOK && dataOK {
-				sData = kvData
-			}
 		} else {
 			sData = s.Data
 		}

--- a/loader/klvault/vaultloader.go
+++ b/loader/klvault/vaultloader.go
@@ -1,6 +1,7 @@
 package klvault
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -184,8 +185,12 @@ func (vl *Loader) Load(cs konfig.Values) error {
 		// confirming version exists on metadata and it is an int
 		if m, ok := s.Data["metadata"].(map[string]interface{}); ok {
 			kvData, dataOK := s.Data["data"].(map[string]interface{})
-			_, versionOK := m["version"].(int)
-			if versionOK && dataOK {
+			_, versionJSONNumberOK := m["version"].(json.Number)
+			if versionJSONNumberOK && dataOK {
+				sData = kvData
+			}
+			_, versionIntOK := m["version"].(int)
+			if versionIntOK && dataOK {
 				sData = kvData
 			}
 		} else {

--- a/loader/klvault/vaultloader_test.go
+++ b/loader/klvault/vaultloader_test.go
@@ -1,6 +1,7 @@
 package klvault
 
 import (
+	"encoding/json"
 	"errors"
 	"sync"
 	"testing"
@@ -75,7 +76,7 @@ func TestVaultLoader(t *testing.T) {
 								"created_time":  "2018-03-22T02:24:06.945319214Z",
 								"deletion_time": "",
 								"destroyed":     false,
-								"version":       1,
+								"version":       json.Number("1"),
 							},
 						},
 						LeaseDuration: int(1 * time.Hour / time.Second),
@@ -92,7 +93,7 @@ func TestVaultLoader(t *testing.T) {
 								"created_time":  "2018-03-22T02:24:06.945319214Z",
 								"deletion_time": "",
 								"destroyed":     false,
-								"version":       1,
+								"version":       json.Number("1"),
 							},
 						},
 						LeaseDuration: int(1 * time.Hour / time.Second),


### PR DESCRIPTION
Vault API client uses `dec.UseNumber` before decoding a response from the Vault HTTP API, therefore, numbers are of type `json.Number` not `int` nor `float64`. 

The current implementation for vault kv version 2 expected the `version` key in metadata to be an `int` which it isnt so it doesn't work. Implementation was changed to check for a `json.Number`.

https://github.com/hashicorp/vault/blob/master/sdk/helper/jsonutil/json.go#L96