### PR TITLE
Bugfix for Reading KV Version 2 Values

### DIFF
--- a/loader/klvault/vaultloader.go
+++ b/loader/klvault/vaultloader.go
@@ -177,7 +177,7 @@ func (vl *Loader) Load(cs konfig.Values) error {
 		if err != nil {
 			return err
 		}
-		s, err = vl.logicalClient.ReadWithData(k, p.Query())
+		s, err = vl.logicalClient.ReadWithData(p.Path, p.Query())
 		if err != nil {
 			return err
 		}

--- a/loader/klvault/vaultloader_test.go
+++ b/loader/klvault/vaultloader_test.go
@@ -83,7 +83,7 @@ func TestVaultLoader(t *testing.T) {
 					},
 					nil,
 				)
-				lC.EXPECT().ReadWithData("dummy/secret/data/path3?version=1", map[string][]string{"version": []string{"1"}}).Return(
+				lC.EXPECT().ReadWithData("dummy/secret/data/path3", map[string][]string{"version": []string{"1"}}).Return(
 					&vault.Secret{
 						Data: map[string]interface{}{
 							"data": map[string]interface{}{


### PR DESCRIPTION
First of all sorry for missing the condition in #49 
While testing KV V2 support on an actual project I encountered a bug coming in from https://github.com/lalamove/konfig/blob/master/loader/klvault/vaultloader.go#L180 which causes an panic as the full key path is being passed instead of the parsed value. This pull request has the fix for the bug and I have also checked in my test repo to reproduce this error and serve as test when this patch is applied. The repo can be found here: https://github.com/shreyu86/konfig-test .

Once again apologies for the bug, I should have performed an integration test sooner. 