### PR TITLE
Allow to pass a custom login path for vault loader

### DIFF
--- a/loader/klvault/auth/k8s/k8s.go
+++ b/loader/klvault/auth/k8s/k8s.go
@@ -18,7 +18,6 @@ import (
 var _ klvault.AuthProvider = (*VaultAuth)(nil)
 
 const (
-	loginPath                 = "/auth/kubernetes/login"
 	k8sTokenKeyNamespace      = "kubernetes.io/serviceaccount/namespace"
 	k8sTokenKeyServiceAccount = "kubernetes.io/serviceaccount/service-account.name"
 )
@@ -34,6 +33,7 @@ var (
 type VaultAuth struct {
 	cfg           *Config
 	k8sToken      string
+	loginPath     string `default:"/auth/kubernetes/login"`
 	role          string
 	logicalClient klvault.LogicalClient
 }
@@ -101,7 +101,7 @@ func New(cfg *Config) *VaultAuth {
 // {"jwt": "'"$KUBE_TOKEN"'", "role": "{{ SERVICE_ACCOUNT_NAME }}"}
 func (k *VaultAuth) Token() (string, time.Duration, error) {
 	var s, err = k.logicalClient.Write(
-		loginPath,
+		k.loginPath,
 		map[string]interface{}{
 			"jwt":  k.k8sToken,
 			"role": k.role,

--- a/loader/klvault/auth/k8s/k8s_test.go
+++ b/loader/klvault/auth/k8s/k8s_test.go
@@ -243,7 +243,7 @@ func TestToken(t *testing.T) {
 
 			var logicalClient = mocks.NewMockLogicalClient(ctrl)
 			logicalClient.EXPECT().Write(
-				loginPath,
+				"/auth/approle_mountpath",
 				map[string]interface{}{
 					"jwt":  "123",
 					"role": "role",
@@ -257,6 +257,7 @@ func TestToken(t *testing.T) {
 
 			var k = &VaultAuth{
 				k8sToken:      "123",
+				loginPath:     "/auth/approle_mountpath",
 				role:          "role",
 				logicalClient: logicalClient,
 			}
@@ -276,7 +277,7 @@ func TestToken(t *testing.T) {
 
 			var logicalClient = mocks.NewMockLogicalClient(ctrl)
 			logicalClient.EXPECT().Write(
-				loginPath,
+				"/auth/approle_mountpath",
 				map[string]interface{}{
 					"jwt":  "123",
 					"role": "role",
@@ -288,6 +289,7 @@ func TestToken(t *testing.T) {
 
 			var k = &VaultAuth{
 				k8sToken:      "123",
+				loginPath:     "/auth/approle_mountpath",
 				role:          "role",
 				logicalClient: logicalClient,
 			}


### PR DESCRIPTION
We use a custom mount point for authentication and the working vault client config looks like:

```
cache {
    use_auto_auth_token = true
}

listener "tcp" {
    address = "127.0.0.1:8200"
    tls_disable = true
}

auto_auth {
    method "kubernetes" {
        mount_path = "auth/k8s_dev"
        config = {
            role = "testnamespace-dev"
        }
    }

    sink "file" {
        config = {
            path = "/vault/token/vault-token"
        }
    }
}

vault {
    address = "https://vaul.com:8200"
}
```